### PR TITLE
Fixed ris mappings to match serial summons

### DIFF
--- a/lib/summon/ris_mappings.rb
+++ b/lib/summon/ris_mappings.rb
@@ -49,7 +49,7 @@
   'TT  -': blank, #translate title
   'TA  -': blank, #translate author
   'U5  -': ->() { open_url }, #openURL (user-custom field)
-  'UR  -': ->() { url }, #URL
+  'UR  -': ->() { uri }, #URL
   'VL  -': ->() { volume }, #Volume
   'ER  -': blank, #end
 }

--- a/lib/summon/ris_mappings.rb
+++ b/lib/summon/ris_mappings.rb
@@ -33,7 +33,7 @@
   'LB  -': blank, #label
   'M1  -': blank, #number 
   'M3  -': ->() { content_type }, #type of work
-  'N1  -': ->() { isi_cited_references_count ? uri : url }, #Notes
+  'N1  -': blank, #Notes
   'NV  -': blank, #number of volumes
   'OP  -': ->() { publication_place }, #original Publication
   'PB  -': ->() { publisher }, #Publisher
@@ -49,7 +49,7 @@
   'TT  -': blank, #translate title
   'TA  -': blank, #translate author
   'U5  -': ->() { open_url }, #openURL (user-custom field)
-  'UR  -': ->() { uri }, #URL
+  'UR  -': ->() { uri ? uri : link }, #if no URI provided, use link we're given
   'VL  -': ->() { volume }, #Volume
   'ER  -': blank, #end
 }

--- a/lib/summon/ris_mappings.rb
+++ b/lib/summon/ris_mappings.rb
@@ -21,17 +21,20 @@
   'DB  -': ->() { database_title }, #database name
   'DO  -': ->() { doi }, #Digital Object Identifier
   'DP  -': blank, #Database Provider
+  'EP  -': ->() { end_page }, #Endpage
   'ET  -': blank, #Edition
+  'IS  -': ->() { issue }, #series volume
+  'JF  -': ->() { publication_title }, #Periodical Full
   'J2  -': blank, #alternate title
   'KW  -': ->() { subject_terms.tag_per_value }, #keywork
   'L1  -': blank, #file attachments
   'L4  -': blank, #figure
   'LA  -': ->() { languages }, #Language
   'LB  -': blank, #label
-  'M1  -': ->() { issue }, #series volume
+  'M1  -': blank, #number 
   'M3  -': ->() { content_type }, #type of work
   'N1  -': ->() { isi_cited_references_count ? uri : url }, #Notes
-  'NV  -': ->() { volume }, #number of volumes
+  'NV  -': blank, #number of volumes
   'OP  -': ->() { publication_place }, #original Publication
   'PB  -': ->() { publisher }, #Publisher
   'PY  -': ->() { publication_date.year.to_s }, #Publication Year
@@ -40,11 +43,13 @@
   'SN  -': ->() { issns.empty? ? isbns : issns }, #ISSN/ISBN
   'SP  -': ->() { start_page }, #Start Page
   'T1  -': ->() { subtitle ? "#{title}: #{subtitle}" : title}, #Primary Title
+  'T1  -': ->() { subtitle ? "#{title}: #{subtitle}" : title}, #Primary Title
   'T2  -': blank, #secondary title
-  'T3  -': ->() { publication_title }, #Periodical Full
+  'T3  -': blank ,#tertiary title
   'TT  -': blank, #translate title
   'TA  -': blank, #translate author
-  'UR  -': ->() { open_url }, #URL
+  'U5  -': ->() { open_url }, #openURL (user-custom field)
+  'UR  -': ->() { url }, #URL
   'VL  -': ->() { volume }, #Volume
   'ER  -': blank, #end
 }


### PR DESCRIPTION
Fixed RIS mappings to more closely match Endnote RIS exports from http://yale.summon.serialssolutions.com

Following changes were done:

1. Moved publication_title from T3 to JF
2. Moved issue number from M1 to IS
3. Added end_page as EP
4. Removed NV as "volume" is not "number of volumes"
5. Moved OpenURL token from URL to user-defined field

Testing steps:

1. Point your search-frontend `Gemfile` to point to branch:
`gem summon-citation_export, :git => 'git@github.com:yalelibrary/summon-sitation_export.git', branch: '6_fix_ris_mappings'
2. Search Articles+
3. Export to Endnote
4. In Endnote, verify the following field mappings:
* Journal: Journal title
* Pages: Start and end pages
* Issue number: Journal issue number
* Verify all other fields look sane/correct