### PR TITLE
Ref type generic

### DIFF
--- a/lib/summon/ris_content_types.yaml
+++ b/lib/summon/ris_content_types.yaml
@@ -80,7 +80,7 @@ Journal: JFULL
 Journal Article: JOUR
 Kit:
 Library Holding:
-Magazine: 
+Magazine: MGZN 
 Magazine Article: MGZN
 Manuscript: MANSCPT
 Map: MAP
@@ -96,7 +96,7 @@ Newsletter:
 Newspaper: NEWS
 Newspaper Article: NEWS
 Painting: ART
-Pamphlet:
+Pamphlet: PAMP
 Paper: 
 Patent: PAT
 Personal Article: PCOMM

--- a/lib/summon/ris_mappings.rb
+++ b/lib/summon/ris_mappings.rb
@@ -8,7 +8,7 @@
 #so some mappings are inevitably going to be blank.
 
 {
-  'TY  -':  ->{ content_type_to_ris_type }, #Reference Type temp use this as the function name
+  'TY  -': ->() { content_type_to_ris_type }, #Reference Type temp use this as the function name
   'AU  -': ->() { authors.map(&:name) + corporate_authors.map(&:name) }, #Primary Authors
   'A2  -': blank, #Secondary Authors
   'A3  -': blank, #Tertiary Authors
@@ -49,7 +49,7 @@
   'TT  -': blank, #translate title
   'TA  -': blank, #translate author
   'U5  -': ->() { open_url }, #openURL (user-custom field)
-  'UR  -': ->() { uri ? uri : link }, #if no URI provided, use link we're given
+  'UR  -': ->() { link ? link : uri }, #if no URI provided, use link we're given
   'VL  -': ->() { volume }, #Volume
   'ER  -': blank, #end
 }

--- a/lib/summon/ris_mappings.rb
+++ b/lib/summon/ris_mappings.rb
@@ -43,7 +43,6 @@
   'SN  -': ->() { issns.empty? ? isbns : issns }, #ISSN/ISBN
   'SP  -': ->() { start_page }, #Start Page
   'T1  -': ->() { subtitle ? "#{title}: #{subtitle}" : title}, #Primary Title
-  'T1  -': ->() { subtitle ? "#{title}: #{subtitle}" : title}, #Primary Title
   'T2  -': blank, #secondary title
   'T3  -': blank ,#tertiary title
   'TT  -': blank, #translate title


### PR DESCRIPTION
- Changes in RIS_mapping.rb:
    Deleted duplicate  T1 
    Formatted 'TY'
    UR: use link (yale link) first, then uri
   Moved issue number from M1 to IS

- Changes in ris_content_types.yaml
  add Magazine and Pamphlet type

Testing steps:

Point your search-frontend Gemfile to branch:
`gem summon-citation_export, :git => 'git@github.com:yalelibrary/summon-sitation_export.git', branch: 'ref_type_generic'
Search Articles+
Export to RefWorks or Export to Endnote
In Endnote, verify the UR field in ris file/Links in RefWorks:
UR field starts with http://yale.summon.serialssolutions.com/2.0.0/link/
Verify all other fields look correct